### PR TITLE
i22 EPUB not generating

### DIFF
--- a/chart/princeton-manifold/templates/configmap-env.yaml
+++ b/chart/princeton-manifold/templates/configmap-env.yaml
@@ -30,4 +30,5 @@ data:
   RAILS_ENV: production
   RAILS_REDIS_URL: {{ template "princeton-manifold.redis.url" . }}
   RAILS_SECRET_KEY: {{ .Values.env.rails_secret_key }}
+  REDIS_URL: {{ template "princeton-manifold.redis.url" . }}
   SSL_ENABLED: "true"


### PR DESCRIPTION
Ref:
- https://github.com/notch8/princeton-manifold/issues/34

The job responsible for generating EPUBs uses the `activejob-uniqueness` gem for advisory locking. This gem needs the `REDIS_URL` env variable to be set to know where to connect to; the job was failing because it was trying to delete a lock from `localhost:6379`.