### PR TITLE
Update to add resource requests and limits for production

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -43,6 +43,14 @@ api:
     host: princeton-manifold-production-api-rails
   cable:
     host: princeton-manifold-production-api-cable
+  sidekiq:
+    resources:
+      limits:
+        memory: "4Gi"
+        cpu: "300m"
+      requests:
+        memory: "2Gi"
+        cpu: "150m"
 
 client:
   replicaCount: 2


### PR DESCRIPTION
Update to add resource requests and limits for production

Ref #43 (side quest due to deploy failure)

# Story
Deploy to production failed on 5/23/25 with [error](https://github.com/notch8/princeton-manifold/actions/runs/15225014620/job/42825909648#step:6:89):
```
Error: UPGRADE FAILED: template: princeton-manifold/templates/deployment-api-sidekiq.yaml:42:30: executing "princeton-manifold/templates/deployment-api-sidekiq.yaml" at <.Values.api.sidekiq.resources>: nil pointer evaluating interface {}.resources
```