### PR TITLE
fix-sentry-error-loop

### DIFF
--- a/api/config/initializers/sentry.rb
+++ b/api/config/initializers/sentry.rb
@@ -6,8 +6,7 @@ require "sentry-sidekiq"
 
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
-  config.environment = ENV["SENTRY_ENVIRONMENT"]
-  config.breadcrumbs_logger = [:active_support_logger, :http_logger, :sentry_logger]
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.enabled_environments = %w[princeton-manifold-friends princeton-manifold-production]
   config.debug = true
 end

--- a/api/config/initializers/sentry.rb
+++ b/api/config/initializers/sentry.rb
@@ -6,6 +6,7 @@ require "sentry-sidekiq"
 
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
+  config.environment = ENV["SENTRY_ENVIRONMENT"]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.enabled_environments = %w[princeton-manifold-friends princeton-manifold-production]
   config.debug = true


### PR DESCRIPTION
- Remove sentry_logger to prevent circular error seen on multiple other projects.